### PR TITLE
Replace network calls with node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1327,6 +1327,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
+      "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -2975,6 +2984,13 @@
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
       }
     },
     "cross-spawn": {
@@ -7461,9 +7477,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/chai": "^4.2.3",
     "@types/expect": "^1.20.4",
     "@types/mocha": "^5.2.7",
+    "@types/node-fetch": "^2.5.2",
     "@types/request": "^2.48.3",
     "@types/sinon": "^7.0.13",
     "chai": "^4.2.0",
@@ -91,6 +92,7 @@
     "eventemitter3": "^4.0.0",
     "js-logger": "^1.6.0",
     "jsontokens": "^2.0.2",
+    "node-fetch": "^2.6.0",
     "regenerator-runtime": "^0.13.3"
   }
 }

--- a/src/packages/utils.ts
+++ b/src/packages/utils.ts
@@ -1,5 +1,5 @@
 import * as bitcoin from "bitcoinjs-lib";
-import request from "request";
+import fetch from "node-fetch";
 import {getLogger} from "../index";
 import { IBitcoinKeyPair } from "./name-service/blockstack-service";
 import { LocalStorage } from "./storage";
@@ -7,13 +7,26 @@ import { LocalStorage } from "./storage";
 const log = getLogger(__filename);
 
 /* istanbul ignore next */
-const httpJSONRequest = (options: (request.UriOptions & request.CoreOptions) | (request.UrlOptions & request.CoreOptions)): Promise<object> => {
+const httpJSONRequest = (options: any): Promise<object> => {
     log.debug("network_call:", options);
     const promise: Promise<object> = new Promise((resolve, reject) => {
-        request(options, (error, response, body) => {
-            if (error) { reject(new Error(error)); }
-            resolve(body);
-        });
+        const fetchOptions = JSON.parse(JSON.stringify(options));
+        delete fetchOptions.baseUrl;
+        delete fetchOptions.url;
+        let url: string = "";
+        if (options.baseUrl) {
+            url += options.baseUrl;
+        }
+        if (options.url) {
+            url += options.url;
+        }
+        if (options.body) {
+            fetchOptions.body = JSON.stringify(options.body);
+        }
+        fetch(url, fetchOptions)
+            .then((res) => res.json())
+            .then((json) => resolve(json))
+            .catch((err) => reject(new Error(err)));
     });
     return promise;
 };


### PR DESCRIPTION
We were using node's request library which was dependant on many core node modules so to get rid of these dependencies which create problem while using js-sdk in react-native moving to node-fetch.

Example of its usage from node-fetch docs.

https://github.com/bitinn/node-fetch#post-with-json