### PR TITLE
Init call transferred to constructor as a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Refer [error-handling.md](https://github.com/cruxprotocol/js-sdk/blob/master/err
 2. ##### getAssetMap()
     - Description: Get Wallet's asset map with currency symbols as the keys and asset object as the value.
     - Params: None
-    - Returns: [IResolvedClientAssetMapping](#iresolvedclientassetmapping) which has symbols and asset objects.
+    - Returns: Promise resolving to [IResolvedClientAssetMapping](#iresolvedclientassetmapping) which has symbols and asset objects.
 
 3. ##### registerCruxID(cruxID<onlySubdomain>)
     - Description: Reserves/registers the cruxID for the user. The user can link any blockchain address to his CruxID immediately after registration using [putAddressMap](#putaddressmap).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To initialize the sdk, you need to minimally pass a javascript object with follo
 
 `**Note:** Cruxprotocol JS SDK is case insensetive for cryptocurrency symbols and will always output lowercase symbols.`
 
-Example below shows how to a cruxClient instance. Note that all [SDK Operation](#sdk-operation) can oly be run after `.init()` is called.   
+Example below shows how to a cruxClient instance. These are the [SDK Operation](#sdk-operation) exposed.   
 ```javascript
 import crypto from "crypto";
 
@@ -45,12 +45,6 @@ let cruxClientOptions = {
 }
 
 let cruxClient = new CruxClient(cruxClientOptions);
-cruxClient.init()
-.then(() => {
-    console.log('CruxClient initialized');
-}).catch((err) => {
-    console.log('CruxClient error', err);
-})
 ```
 That's it! now you can use the cruxClient object to perform operations defined in [SDK Operation](#sdk-operation).
 ```javascript
@@ -62,7 +56,6 @@ cruxClient.getCruxIDState().then((cruxIDState) => {
 Wallet clients are encouraged to surface the respective `ERROR_CODE` of the `CruxClientError` to their Users with any custom error messages. This will help in debugging any issues with the functionality.
 
 Refer [error-handling.md](https://github.com/cruxprotocol/js-sdk/blob/master/error-handling.md) for more information on Error handling.
-
 
 
 ### SDK Operation

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,9 @@ export class CruxClient {
         this.initPromise = this._init();
     }
 
-    public init = () => this._init;    // For backward compatibility
+    public init = async (): Promise<void> => {
+        return await this.initPromise;
+    }   // For backward compatibility
 
     public hasPayIDClaim = (): boolean =>  {
         return Boolean(this._payIDClaim);

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,6 @@ export class CruxClient {
         }
     }
 
-    public isCruxClientInitialized: boolean = false;
     public walletClientName: string;
     protected _options: ICruxPayPeerOptions;
     protected _getEncryptionKey: () => string;
@@ -166,6 +165,7 @@ export class CruxClient {
     protected _nameService?: nameService.NameService;
     protected _payIDClaim?: PayIDClaim;
     protected _configService?: configurationService.ConfigurationService;
+    private initPromise: Promise<void>;
 
     constructor(options: ICruxPayPeerOptions) {
         this._options = Object.assign({}, options);
@@ -186,9 +186,219 @@ export class CruxClient {
 
         log.info(`Config mode:`, config.CONFIG_MODE);
         log.info(`CruxPayClient: constructor called`);
+        this.initPromise = this._init();
     }
 
-    public init = async (): Promise<void> => {
+    public init = () => this._init;    // For backward compatibility
+
+    public hasPayIDClaim = (): boolean =>  {
+        return Boolean(this._payIDClaim);
+    }
+
+    public getPayIDClaim = (): PayIDClaim => {
+        return (this._payIDClaim as PayIDClaim);
+    }
+
+    public updatePassword = async (oldEncryptionKey: string, newEncryptionKey: string): Promise<boolean> => {
+        return this.initPromise.then(async () => {
+            try {
+                if (await this._hasPayIDClaimStored()) {
+                    await (this._payIDClaim as PayIDClaim).decrypt(oldEncryptionKey);
+                    try {
+                        await (this._payIDClaim as PayIDClaim).encrypt(newEncryptionKey);
+                    } catch (err) {
+                        await (this._payIDClaim as PayIDClaim).encrypt(oldEncryptionKey);
+                        return false;
+                    }
+                    await (this._payIDClaim as PayIDClaim).save(this._storage);
+                    return true;
+                } else {
+                    return true;
+                }
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public isCruxIDAvailable = async (cruxIDSubdomain: string): Promise<boolean> => {
+        return this.initPromise.then(async () => {
+            try {
+                identityUtils.validateSubdomain(cruxIDSubdomain);
+                return (this._nameService as nameService.NameService).getNameAvailability(cruxIDSubdomain);
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public resolveCurrencyAddressForCruxID = async (fullCruxID: string, walletCurrencySymbol: string): Promise<IAddress> => {
+        return this.initPromise.then(async () => {
+            try {
+                if (!(this._configService && this._nameService)) {
+                    throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ClientNotInitialized);
+                }
+                walletCurrencySymbol = walletCurrencySymbol.toLowerCase();
+                let correspondingAssetId: string = "";
+                correspondingAssetId = await this._translateSymbolToAssetId(walletCurrencySymbol);
+                if (!correspondingAssetId) {
+                    throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.AssetIDNotAvailable);
+                }
+
+                const addressMap = await this._nameService.getAddressMapping(fullCruxID);
+                log.debug(`Address map: `, addressMap);
+                if (!addressMap[correspondingAssetId]) {
+                    throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.AddressNotAvailable);
+                }
+                const address: IAddress = addressMap[correspondingAssetId] || addressMap[correspondingAssetId.toLowerCase()];
+                log.debug(`Address:`, address);
+                return address;
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public getCruxIDState = async (): Promise<ICruxIDState> => {
+        return this.initPromise.then(async () => {
+            try {
+                const fullCruxID = this.hasPayIDClaim() ? this.getPayIDClaim().virtualAddress : undefined;
+                if (!fullCruxID) {
+                    return {
+                        cruxID: null,
+                        status: {
+                            status: "NONE",
+                            statusDetail: "",
+                        },
+                    };
+                }
+                const status = await this._getIDStatus();
+                return {
+                    cruxID: fullCruxID,
+                    status,
+                };
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public registerCruxID = async (cruxIDSubdomain: string): Promise<void> => {
+        // TODO: add isCruxIDAvailable check before
+        return this.initPromise.then(async () => {
+            try {
+                // Subdomain validation
+                identityUtils.validateSubdomain(cruxIDSubdomain);
+
+                // Validate if the subdomain is available
+                if (!(await this.isCruxIDAvailable(cruxIDSubdomain))) {
+                    throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.CruxIDUnavailable, cruxIDSubdomain);
+                }
+
+                // Generating the identityClaim
+                if (this._payIDClaim) {
+                    if (this._payIDClaim.virtualAddress) {
+                        // Do not allow multiple registrations using same payIDClaim
+                        throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ExistingCruxIDFound, this._payIDClaim.virtualAddress);
+                    }
+                    await (this._payIDClaim as PayIDClaim).decrypt();
+                }
+
+                let identityClaim: nameService.IIdentityClaim;
+                if (this._payIDClaim) {
+                    identityClaim = {secrets: this._payIDClaim.identitySecrets};
+                } else if (this._keyPair) {
+                    identityClaim = {secrets: {identityKeyPair: this._keyPair}};
+                } else {
+                    identityClaim = await (this._nameService as nameService.NameService).generateIdentity(this._storage, await this._getEncryptionKey());
+                }
+
+                const registeredPublicID = await (this._nameService as nameService.NameService).registerName(identityClaim, cruxIDSubdomain);
+
+                // Setup the payIDClaim locally
+                this._setPayIDClaim(new PayIDClaim({virtualAddress: registeredPublicID, identitySecrets: identityClaim.secrets}, { getEncryptionKey: this._getEncryptionKey }));
+                // await this._payIDClaim.setPasscode(passcode)
+                await (this._payIDClaim as PayIDClaim).encrypt();
+                await (this._payIDClaim as PayIDClaim).save(this._storage);
+                return;
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public putAddressMap = async (newAddressMap: IAddressMapping): Promise<{success: IPutAddressMapSuccess, failures: IPutAddressMapFailures}> => {
+        return this.initPromise.then(async () => {
+            try {
+                const {assetAddressMap, success, failures} = await this._getAssetAddressMapFromCurrencyAddressMap(newAddressMap);
+                await (this._payIDClaim as PayIDClaim).decrypt();
+                await (this._nameService as nameService.NameService).putAddressMapping({secrets: (this._payIDClaim as PayIDClaim).identitySecrets}, assetAddressMap);
+                await (this._payIDClaim as PayIDClaim).encrypt();
+                return {success, failures};
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public getAddressMap = async (): Promise<IAddressMapping> => {
+        return this.initPromise.then(async () => {
+            try {
+                const currencyAddressMap: IAddressMapping = {};
+                if (this._payIDClaim && this._payIDClaim.virtualAddress && this._configService) {
+                    const userAssetIdToAddressMap = await (this._nameService as nameService.NameService).getAddressMapping(this._payIDClaim.virtualAddress);
+
+                    for (const assetId of Object.keys(userAssetIdToAddressMap)) {
+                        currencyAddressMap[(await (this._translateAssetIdToSymbol(assetId)))] = userAssetIdToAddressMap[assetId];
+                    }
+                    return currencyAddressMap;
+                } else {
+                    return {};
+                }
+            } catch (err) {
+                if (err.errorCode && err.errorCode === errors.PackageErrorCode.GaiaEmptyResponse) {
+                    return {};
+                }
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public getAssetMap = async (): Promise<configurationService.IResolvedClientAssetMap> => {
+        return this.initPromise.then(async () => {
+            try {
+                // @ts-ignore
+                return this._configService.resolvedClientAssetMap as configurationService.IResolvedClientAssetMap;
+            } catch (err) {
+                throw errors.CruxClientError.fromError(err);
+            }
+        }).catch((err) => {
+            throw err;
+        });
+    }
+
+    public getAssetMapping = () => this.getAssetMap;    // For backward compatibility
+
+    protected _setPayIDClaim = (payIDClaim: PayIDClaim): void => {
+        this._payIDClaim = payIDClaim;
+        delete this._keyPair;
+    }
+
+    private _init = async (): Promise<void> => {
         await this._setupConfigService();
         if (!this._configService) {
             throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ClientNotInitialized);
@@ -223,198 +433,7 @@ export class CruxClient {
 
         await this._initializeNameService().then(() => this._restoreIdentity());
 
-        log.info(`CruxPayClient: init complete`);
-    }
-
-    public hasPayIDClaim = (): boolean =>  {
-        return Boolean(this._payIDClaim);
-    }
-
-    public getPayIDClaim = (): PayIDClaim => {
-        return (this._payIDClaim as PayIDClaim);
-    }
-
-    public updatePassword = async (oldEncryptionKey: string, newEncryptionKey: string): Promise<boolean> => {
-        await this._init();
-        try {
-            if (await this._hasPayIDClaimStored()) {
-                await (this._payIDClaim as PayIDClaim).decrypt(oldEncryptionKey);
-                try {
-                    await (this._payIDClaim as PayIDClaim).encrypt(newEncryptionKey);
-                } catch (err) {
-                    await (this._payIDClaim as PayIDClaim).encrypt(oldEncryptionKey);
-                    return false;
-                }
-                await (this._payIDClaim as PayIDClaim).save(this._storage);
-                return true;
-            } else {
-                return true;
-            }
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public isCruxIDAvailable = async (cruxIDSubdomain: string): Promise<boolean> => {
-        await this._init();
-        try {
-            identityUtils.validateSubdomain(cruxIDSubdomain);
-            return (this._nameService as nameService.NameService).getNameAvailability(cruxIDSubdomain);
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public resolveCurrencyAddressForCruxID = async (fullCruxID: string, walletCurrencySymbol: string): Promise<IAddress> => {
-        await this._init();
-        try {
-            if (!(this._configService && this._nameService)) {
-                throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ClientNotInitialized);
-            }
-            walletCurrencySymbol = walletCurrencySymbol.toLowerCase();
-            let correspondingAssetId: string = "";
-            correspondingAssetId = await this._translateSymbolToAssetId(walletCurrencySymbol);
-            if (!correspondingAssetId) {
-                throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.AssetIDNotAvailable);
-            }
-
-            const addressMap = await this._nameService.getAddressMapping(fullCruxID);
-            log.debug(`Address map: `, addressMap);
-            if (!addressMap[correspondingAssetId]) {
-                throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.AddressNotAvailable);
-            }
-            const address: IAddress = addressMap[correspondingAssetId] || addressMap[correspondingAssetId.toLowerCase()];
-            log.debug(`Address:`, address);
-            return address;
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public getCruxIDState = async (): Promise<ICruxIDState> => {
-        await this._init();
-        try {
-            const fullCruxID = this.hasPayIDClaim() ? this.getPayIDClaim().virtualAddress : undefined;
-            if (!fullCruxID) {
-                return {
-                    cruxID: null,
-                    status: {
-                        status: "NONE",
-                        statusDetail: "",
-                    },
-                };
-            }
-            const status = await this._getIDStatus();
-            return {
-                cruxID: fullCruxID,
-                status,
-            };
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public registerCruxID = async (cruxIDSubdomain: string): Promise<void> => {
-        // TODO: add isCruxIDAvailable check before
-        await this._init();
-        try {
-            // Subdomain validation
-            identityUtils.validateSubdomain(cruxIDSubdomain);
-
-            // Validate if the subdomain is available
-            if (!(await this.isCruxIDAvailable(cruxIDSubdomain))) {
-                throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.CruxIDUnavailable, cruxIDSubdomain);
-            }
-
-            // Generating the identityClaim
-            if (this._payIDClaim) {
-                if (this._payIDClaim.virtualAddress) {
-                    // Do not allow multiple registrations using same payIDClaim
-                    throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ExistingCruxIDFound, this._payIDClaim.virtualAddress);
-                }
-                await (this._payIDClaim as PayIDClaim).decrypt();
-            }
-
-            let identityClaim: nameService.IIdentityClaim;
-            if (this._payIDClaim) {
-                identityClaim = {secrets: this._payIDClaim.identitySecrets};
-            } else if (this._keyPair) {
-                identityClaim = {secrets: {identityKeyPair: this._keyPair}};
-            } else {
-                identityClaim = await (this._nameService as nameService.NameService).generateIdentity(this._storage, await this._getEncryptionKey());
-            }
-
-            const registeredPublicID = await (this._nameService as nameService.NameService).registerName(identityClaim, cruxIDSubdomain);
-
-            // Setup the payIDClaim locally
-            this._setPayIDClaim(new PayIDClaim({virtualAddress: registeredPublicID, identitySecrets: identityClaim.secrets}, { getEncryptionKey: this._getEncryptionKey }));
-            // await this._payIDClaim.setPasscode(passcode)
-            await (this._payIDClaim as PayIDClaim).encrypt();
-            await (this._payIDClaim as PayIDClaim).save(this._storage);
-            return;
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public putAddressMap = async (newAddressMap: IAddressMapping): Promise<{success: IPutAddressMapSuccess, failures: IPutAddressMapFailures}> => {
-        await this._init();
-        try {
-            const {assetAddressMap, success, failures} = await this._getAssetAddressMapFromCurrencyAddressMap(newAddressMap);
-            await (this._payIDClaim as PayIDClaim).decrypt();
-            await (this._nameService as nameService.NameService).putAddressMapping({secrets: (this._payIDClaim as PayIDClaim).identitySecrets}, assetAddressMap);
-            await (this._payIDClaim as PayIDClaim).encrypt();
-            return {success, failures};
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public getAddressMap = async (): Promise<IAddressMapping> => {
-        await this._init();
-        try {
-            const currencyAddressMap: IAddressMapping = {};
-            if (this._payIDClaim && this._payIDClaim.virtualAddress && this._configService) {
-                const userAssetIdToAddressMap = await (this._nameService as nameService.NameService).getAddressMapping(this._payIDClaim.virtualAddress);
-
-                for (const assetId of Object.keys(userAssetIdToAddressMap)) {
-                    currencyAddressMap[(await (this._translateAssetIdToSymbol(assetId)))] = userAssetIdToAddressMap[assetId];
-                }
-                return currencyAddressMap;
-
-            } else {
-                return {};
-            }
-        } catch (err) {
-            if (err.errorCode && err.errorCode === errors.PackageErrorCode.GaiaEmptyResponse) {
-                return {};
-            }
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public getAssetMap = async (): Promise<configurationService.IResolvedClientAssetMap> => {
-        await this._init();
-        try {
-            // @ts-ignore
-            return this._configService.resolvedClientAssetMap as configurationService.IResolvedClientAssetMap;
-        } catch (err) {
-            throw errors.CruxClientError.fromError(err);
-        }
-    }
-
-    public getAssetMapping = () => this.getAssetMap;    // For backward compatibility
-
-    protected _setPayIDClaim = (payIDClaim: PayIDClaim): void => {
-        this._payIDClaim = payIDClaim;
-        delete this._keyPair;
-    }
-
-    private async _init() {
-        if (!this.isCruxClientInitialized) {
-            await this.init();
-            this.isCruxClientInitialized = true;
-        }
+        log.info(`CruxPayClient: _init complete`);
     }
 
     private _getIDStatus = async (): Promise<nameService.CruxIDRegistrationStatus> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,45 +202,39 @@ export class CruxClient {
     }
 
     public updatePassword = async (oldEncryptionKey: string, newEncryptionKey: string): Promise<boolean> => {
-        return this.initPromise.then(async () => {
-            try {
-                if (await this._hasPayIDClaimStored()) {
-                    await (this._payIDClaim as PayIDClaim).decrypt(oldEncryptionKey);
-                    try {
-                        await (this._payIDClaim as PayIDClaim).encrypt(newEncryptionKey);
-                    } catch (err) {
-                        await (this._payIDClaim as PayIDClaim).encrypt(oldEncryptionKey);
-                        return false;
-                    }
-                    await (this._payIDClaim as PayIDClaim).save(this._storage);
-                    return true;
-                } else {
-                    return true;
+        await this.initPromise;
+        try {
+            if (await this._hasPayIDClaimStored()) {
+                await (this._payIDClaim as PayIDClaim).decrypt(oldEncryptionKey);
+                try {
+                    await (this._payIDClaim as PayIDClaim).encrypt(newEncryptionKey);
+                } catch (err) {
+                    await (this._payIDClaim as PayIDClaim).encrypt(oldEncryptionKey);
+                    return false;
                 }
-            } catch (err) {
-                throw errors.CruxClientError.fromError(err);
+                await (this._payIDClaim as PayIDClaim).save(this._storage);
+                return true;
+            } else {
+                return true;
             }
-        }).catch((err) => {
-            throw err;
-        });
+        } catch (err) {
+            throw errors.CruxClientError.fromError(err);
+        }
     }
 
     public isCruxIDAvailable = async (cruxIDSubdomain: string): Promise<boolean> => {
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 identityUtils.validateSubdomain(cruxIDSubdomain);
                 return (this._nameService as nameService.NameService).getNameAvailability(cruxIDSubdomain);
             } catch (err) {
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public resolveCurrencyAddressForCruxID = async (fullCruxID: string, walletCurrencySymbol: string): Promise<IAddress> => {
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 if (!(this._configService && this._nameService)) {
                     throw errors.ErrorHelper.getPackageError(errors.PackageErrorCode.ClientNotInitialized);
                 }
@@ -262,41 +256,35 @@ export class CruxClient {
             } catch (err) {
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public getCruxIDState = async (): Promise<ICruxIDState> => {
-        return this.initPromise.then(async () => {
-            try {
-                const fullCruxID = this.hasPayIDClaim() ? this.getPayIDClaim().virtualAddress : undefined;
-                if (!fullCruxID) {
-                    return {
-                        cruxID: null,
-                        status: {
-                            status: "NONE",
-                            statusDetail: "",
-                        },
-                    };
-                }
-                const status = await this._getIDStatus();
+        await this.initPromise;
+        try {
+            const fullCruxID = this.hasPayIDClaim() ? this.getPayIDClaim().virtualAddress : undefined;
+            if (!fullCruxID) {
                 return {
-                    cruxID: fullCruxID,
-                    status,
+                    cruxID: null,
+                    status: {
+                        status: "NONE",
+                        statusDetail: "",
+                    },
                 };
-            } catch (err) {
-                throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
+            const status = await this._getIDStatus();
+            return {
+                cruxID: fullCruxID,
+                status,
+            };
+        } catch (err) {
+            throw errors.CruxClientError.fromError(err);
+        }
     }
 
     public registerCruxID = async (cruxIDSubdomain: string): Promise<void> => {
         // TODO: add isCruxIDAvailable check before
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 // Subdomain validation
                 identityUtils.validateSubdomain(cruxIDSubdomain);
 
@@ -334,14 +322,11 @@ export class CruxClient {
             } catch (err) {
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public putAddressMap = async (newAddressMap: IAddressMapping): Promise<{success: IPutAddressMapSuccess, failures: IPutAddressMapFailures}> => {
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 const {assetAddressMap, success, failures} = await this._getAssetAddressMapFromCurrencyAddressMap(newAddressMap);
                 await (this._payIDClaim as PayIDClaim).decrypt();
                 await (this._nameService as nameService.NameService).putAddressMapping({secrets: (this._payIDClaim as PayIDClaim).identitySecrets}, assetAddressMap);
@@ -350,14 +335,11 @@ export class CruxClient {
             } catch (err) {
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public getAddressMap = async (): Promise<IAddressMapping> => {
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 const currencyAddressMap: IAddressMapping = {};
                 if (this._payIDClaim && this._payIDClaim.virtualAddress && this._configService) {
                     const userAssetIdToAddressMap = await (this._nameService as nameService.NameService).getAddressMapping(this._payIDClaim.virtualAddress);
@@ -375,22 +357,16 @@ export class CruxClient {
                 }
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public getAssetMap = async (): Promise<configurationService.IResolvedClientAssetMap> => {
-        return this.initPromise.then(async () => {
-            try {
+        await this.initPromise;
+        try {
                 // @ts-ignore
                 return this._configService.resolvedClientAssetMap as configurationService.IResolvedClientAssetMap;
             } catch (err) {
                 throw errors.CruxClientError.fromError(err);
             }
-        }).catch((err) => {
-            throw err;
-        });
     }
 
     public getAssetMapping = () => this.getAssetMap;    // For backward compatibility

--- a/src/samples/wallet_demo.html
+++ b/src/samples/wallet_demo.html
@@ -29,12 +29,13 @@
             display: block;
         }
     </style>
-    
+
     <h4>Demo Wallet</h4>
     <br><span class="helper">wallet client:</span> <span class="walletClientName"></span><br>
     <br><span class="helper">wallet addresses:</span><br>
     <pre id="userAddresses"></pre>
     <br><span class="helper">wallet encryption key:</span> <span id="encryptionKey"></span><br>
+    <br><span class="helper">Init Mode:</span> <span id="mode"></span><br>
 
     ========================
 
@@ -43,7 +44,7 @@
     <div id="init">
         Initialising cruxClient...
     </div>
-    
+
     <div class="registered unregistered">
         <br><span class="helper">cruxID status:</span><br>
         <pre id="cruxIDStatus"></pre>
@@ -54,7 +55,7 @@
         <input id="registrationId" placeholder="ankit" style="text-align: right;">@<span class="walletClientName"></span>.crux <button onclick="isCruxIDAvailable()">Check</button><br>
         <pre id='availability'></pre>
     </div>
-    
+
     <div class="unregistered">
         <br><span class="helper">cruxID registration:</span><br>
         <input id="newSubdomain" placeholder="ankit" style="text-align: right;">@<span class="walletClientName"></span>.crux <button onclick="registerCruxID()">Register</button>
@@ -80,13 +81,13 @@
         <button onclick="getAddressMap()">Get Public Addresses</button>
         <pre id="addressMap"></pre>
     </div>
-    
+
     <div class="registered">
         <br><span class="helper">publish address map:</span><br>
         <div id="publishAddresses"></div><br>
         <button onclick="putAddressMap()">Publish Address</button>
         <pre id="putAddressMapAcknowledgement"></pre>
-    </div>   
+    </div>
 
     <div class="registered">
         <br><span class="helper">change password (effectively encryptionKey):</span><br>

--- a/src/samples/wallet_demo.ts
+++ b/src/samples/wallet_demo.ts
@@ -232,15 +232,15 @@ const updatePassword = async () => {
     }
 }
 
-// getCruxIDState().then((cruxIDStatus) => {
-//     console.log("works!");
-//     if (cruxIDStatus.status.status === "DONE") {
-//         [].forEach.call(doc.getElementsByClassName('unregistered'), (el: HTMLElement) => { el.style.display = "none" });
-//         [].forEach.call(doc.getElementsByClassName('registered'), (el: HTMLElement) => { el.style.display = "block" });
-//     }
-//     // add hook to enable registered elements
-//     doc.getElementById('init').style.display = "none"
-// });
+getCruxIDState().then((cruxIDStatus) => {
+    console.log("works!");
+    if (cruxIDStatus.status.status === "DONE") {
+        [].forEach.call(doc.getElementsByClassName('unregistered'), (el: HTMLElement) => { el.style.display = "none" });
+        [].forEach.call(doc.getElementsByClassName('registered'), (el: HTMLElement) => { el.style.display = "block" });
+    }
+    // add hook to enable registered elements
+    doc.getElementById('init').style.display = "none"
+});
 
 // Declaring global variables to be accessible for (button clicks or debugging purposes)
 declare global {

--- a/src/samples/wallet_demo.ts
+++ b/src/samples/wallet_demo.ts
@@ -59,22 +59,22 @@ const cruxClientOptions: ICruxPayPeerOptions = {
 
 // initialising the cruxClient
 const cruxClient = new CruxClient(cruxClientOptions)
-cruxClient.init()
-    .then(async () => {
-        let cruxIDStatus = await getCruxIDState()
-        if (cruxIDStatus.status.status === "DONE") {
-            [].forEach.call(doc.getElementsByClassName('unregistered'), (el: HTMLElement) => { el.style.display = "none" });
-            [].forEach.call(doc.getElementsByClassName('registered'), (el: HTMLElement) => { el.style.display = "block" });
-        }
-        // add hook to enable registered elements
-        doc.getElementById('init').style.display = "none"
-    })
-    .catch((error) => {
-        let message = "CruxClient Initialization Error: \n" + error
-        alert(message)
-        console.log(error);
-        doc.getElementById('init').innerHTML = message
-    })
+// cruxClient.init()
+//     .then(async () => {
+//         let cruxIDStatus = await getCruxIDState()
+//         if (cruxIDStatus.status.status === "DONE") {
+//             [].forEach.call(doc.getElementsByClassName('unregistered'), (el: HTMLElement) => { el.style.display = "none" });
+//             [].forEach.call(doc.getElementsByClassName('registered'), (el: HTMLElement) => { el.style.display = "block" });
+//         }
+//         // add hook to enable registered elements
+//         doc.getElementById('init').style.display = "none"
+//     })
+//     .catch((error) => {
+//         let message = "CruxClient Initialization Error: \n" + error
+//         alert(message)
+//         console.log(error);
+//         doc.getElementById('init').innerHTML = message
+//     })
 
 
 // SDK functional interface
@@ -232,6 +232,15 @@ const updatePassword = async () => {
     }
 }
 
+// getCruxIDState().then((cruxIDStatus) => {
+//     console.log("works!");
+//     if (cruxIDStatus.status.status === "DONE") {
+//         [].forEach.call(doc.getElementsByClassName('unregistered'), (el: HTMLElement) => { el.style.display = "none" });
+//         [].forEach.call(doc.getElementsByClassName('registered'), (el: HTMLElement) => { el.style.display = "block" });
+//     }
+//     // add hook to enable registered elements
+//     doc.getElementById('init').style.display = "none"
+// });
 
 // Declaring global variables to be accessible for (button clicks or debugging purposes)
 declare global {

--- a/src/test/cruxclient.ts
+++ b/src/test/cruxclient.ts
@@ -4,7 +4,7 @@ import requestFixtures from './requestMocks/cruxclient-reqmocks';
 import sinon from "sinon";
 import WebCrypto from "node-webcrypto-ossl";
 import { expect } from 'chai';
-import {CruxClient, PayIDClaim} from "../index";
+import {CruxClient, ICruxIDState, PayIDClaim} from "../index";
 import { ErrorHelper, PackageErrorCode } from '../packages/error';
 
 interface Global {
@@ -93,8 +93,7 @@ describe('CruxClient tests', () => {
 				it("getCruxIDState handling empty local storage",async () => {
 					localStorage.clear();
 					let cruxClient = new CruxClient(walletOptions);
-					await cruxClient.init()
-					let cruxIdState = await cruxClient.getCruxIDState()
+					let cruxIdState: ICruxIDState = await cruxClient.getCruxIDState()
 					expect(cruxIdState.status.cruxID).to.equal(undefined)
 				})
 			})
@@ -136,7 +135,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// registerCruxID
 				const subdomain = "cs1";
@@ -156,7 +154,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(false);
@@ -183,7 +180,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
@@ -209,7 +205,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
@@ -248,7 +243,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
@@ -289,7 +283,6 @@ describe('CruxClient tests', () => {
 				localStorage.clear();
 				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init()
 				let mockedSampleAddress = sampleUser['addressMapping']
 
 				let mockedRevserseClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
@@ -307,7 +300,6 @@ describe('CruxClient tests', () => {
 				localStorage.clear();
 				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init()
 				let mockedSampleAddress = sampleUser['addressMapping']
 
 				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
@@ -331,7 +323,6 @@ describe('CruxClient tests', () => {
 				localStorage.clear();
 				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init()
 				let mockedSampleAddress = {"1234567-1e77-41e1-9ebb-0e216faa166a": {addressHash: "19m51F8YkjzK625csaNtKnM9pgByeMJRU3"}}
 
 				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
@@ -356,7 +347,6 @@ describe('CruxClient tests', () => {
 			it("positive case, get address map", async () => {
 				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']));
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init()
 				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
 				let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
 				let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(sampleUser['addressMapping'])
@@ -369,7 +359,6 @@ describe('CruxClient tests', () => {
 			it("put address map, gaia upload call failed", async () => {
 				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init()
 				let raisesException = false
 				let updateProfileStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').rejects(ErrorHelper.getPackageError(PackageErrorCode.GaiaProfileUploadFailed))
 				try {
@@ -392,7 +381,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				// @ts-ignore
@@ -424,7 +412,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				// @ts-ignore
@@ -452,7 +439,6 @@ describe('CruxClient tests', () => {
 
 				// Initialising the CruxClient
 				let cruxClient = new CruxClient(walletOptions);
-				await cruxClient.init();
 
 				// stubbing runtime property
 				// @ts-ignore

--- a/src/test/cruxclient.ts
+++ b/src/test/cruxclient.ts
@@ -4,13 +4,13 @@ import requestFixtures from './requestMocks/cruxclient-reqmocks';
 import sinon from "sinon";
 import WebCrypto from "node-webcrypto-ossl";
 import { expect } from 'chai';
-import {CruxClient, ICruxIDState, PayIDClaim} from "../index";
+import {CruxClient, PayIDClaim} from "../index";
 import { ErrorHelper, PackageErrorCode } from '../packages/error';
 
 interface Global {
-	crypto: any;
-	TextEncoder: any;
-	TextDecoder: any;
+    crypto: any;
+    TextEncoder: any;
+    TextDecoder: any;
 }
 declare const global: Global;
 
@@ -22,443 +22,457 @@ global.TextDecoder = util.TextDecoder
 
 describe('CruxClient tests', () => {
 
-	let sampleAddressMap = {
-		BTC: {
-			addressHash: '1HX4KvtPdg9QUYwQE1kNqTAjmNaDG7w82V'
-		},
-		ETH: {
-			addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
-		}
-	};
-	let mockedAddressMapping = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": {addressHash: "19m51F8YkjzK625csaNtKnM9pgByeMJRU3"}}
-	let sampleUser = {
-		'payIDClaim': {"virtualAddress":"syedhassanashraf@cruxdev.crux","identitySecrets":"{\"iv\":\"d6mQLg2lv/SHvpPV\",\"encBuffer\":\"EJ0NDIGyvT+FMxjG9pD7yKkUVUJffcd0mU3V7rqgbpip5ikCR+kx/Xl4tJcBNtQUJzKbDPNJeeWdzUKH01NQOiyEe9qfCYEqzbJgj4PSqE/B1geSlCMRWcdJMdbrUDHgEcwDWw6PC41p0odNHLzMWOR1LA+PKVzCAMXRom6UppG+gjMnjp9QqF00SfnNR6wla/es7LgE3eF6O4Gq9Ku/mAhdYrZiaMMd47hQvTzH9KzDZrTjK37jmtiRC6cuNDy9zZ+BtpzufozAbuCvfeQc2nXKdV4a3kx7peLK7eAGZUV6soaOfq+ZIPx5bbnNos8Py7fhNOmqbop12yCQ4Ot2jm7Bmx9eXIFq7/EtLWP488xU3l2qB0/XHMmGtlsZ8Er19al+aB4OJAJ5yzBU01rVQFVkOLC50ZlYT4VcVgJbOUvRXi8c4mlv0JNfvajA\"}"},
-		'cruxID': 'syedhassanashraf@cruxdev.crux',
-		'cruxIDSubdomain': 'syedhassanashraf',
-		'addressMapping': mockedAddressMapping,
-		'decryptedPayIDClaim': {"virtualAddress":"syedhassanashraf@cruxdev.crux", "identitySecrets": {"identityKeyPair":{"pubKey":"033f4f33c1483cb15c58c9ca03b2a0847382b0081290017e28be03b55353f1f6eb","privKey":"850433f3a2f12f0fb890041e1daed6bd491a973ec569936d41ac62cb8441ee5101","address":"16DfDLZajnAwRotCx4L1NEkAEAijwsntHV"}}}
-	}
-	let walletOptions = {
-		getEncryptionKey: () => "fookey",
-		walletClientName: 'scatter_dev'
-	}
+    let sampleAddressMap = {
+        BTC: {
+            addressHash: '1HX4KvtPdg9QUYwQE1kNqTAjmNaDG7w82V'
+        },
+        ETH: {
+            addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
+        }
+    };
+    let mockedAddressMapping = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": {addressHash: "19m51F8YkjzK625csaNtKnM9pgByeMJRU3"}}
+    let sampleUser = {
+        'payIDClaim': {"virtualAddress":"syedhassanashraf@cruxdev.crux","identitySecrets":"{\"iv\":\"d6mQLg2lv/SHvpPV\",\"encBuffer\":\"EJ0NDIGyvT+FMxjG9pD7yKkUVUJffcd0mU3V7rqgbpip5ikCR+kx/Xl4tJcBNtQUJzKbDPNJeeWdzUKH01NQOiyEe9qfCYEqzbJgj4PSqE/B1geSlCMRWcdJMdbrUDHgEcwDWw6PC41p0odNHLzMWOR1LA+PKVzCAMXRom6UppG+gjMnjp9QqF00SfnNR6wla/es7LgE3eF6O4Gq9Ku/mAhdYrZiaMMd47hQvTzH9KzDZrTjK37jmtiRC6cuNDy9zZ+BtpzufozAbuCvfeQc2nXKdV4a3kx7peLK7eAGZUV6soaOfq+ZIPx5bbnNos8Py7fhNOmqbop12yCQ4Ot2jm7Bmx9eXIFq7/EtLWP488xU3l2qB0/XHMmGtlsZ8Er19al+aB4OJAJ5yzBU01rVQFVkOLC50ZlYT4VcVgJbOUvRXi8c4mlv0JNfvajA\"}"},
+        'cruxID': 'syedhassanashraf@cruxdev.crux',
+        'cruxIDSubdomain': 'syedhassanashraf',
+        'addressMapping': mockedAddressMapping,
+        'decryptedPayIDClaim': {"virtualAddress":"syedhassanashraf@cruxdev.crux", "identitySecrets": {"identityKeyPair":{"pubKey":"033f4f33c1483cb15c58c9ca03b2a0847382b0081290017e28be03b55353f1f6eb","privKey":"850433f3a2f12f0fb890041e1daed6bd491a973ec569936d41ac62cb8441ee5101","address":"16DfDLZajnAwRotCx4L1NEkAEAijwsntHV"}}}
+    }
+    let walletOptions = {
+        getEncryptionKey: () => "fookey",
+        walletClientName: 'scatter_dev'
+    }
 
-	describe('after init tests', () => {
+    describe('after init tests', () => {
 
-		let httpJSONRequestStub: sinon.SinonStub
+        let httpJSONRequestStub: sinon.SinonStub
 
-		before(() => {
-			httpJSONRequestStub = sinon.stub(utils, 'httpJSONRequest').throws('unhandled in mocks')
+        before(() => {
+            httpJSONRequestStub = sinon.stub(utils, 'httpJSONRequest').throws('unhandled in mocks')
 
             requestFixtures.forEach(requestObj => {
-              httpJSONRequestStub.withArgs(requestObj.request).returns(requestObj.response)
-			});
-		})
-
-		after(() => {
-			httpJSONRequestStub.restore()
-			localStorage.clear();
-		})
-
-		describe('updatePassword tests', () => {
-
-			it('after encryption is mnemonic and identityKeyPair are same', async () => {
-				localStorage.setItem('payIDClaim', JSON.stringify({"identitySecrets":"{\"iv\":\"cxgg/vvP6XlWOwov\",\"encBuffer\":\"DX+FXU8rG4P2BQIZxWIV8R0DSc8WENREtf2PrIybw3cJLjk/90BYvpn+eC5c45Xb4tXHBW7ScxV26nR9OvDT5nT9SNyPZNIsFpnjnC83y31DodxgijK/ZPUGpPeA1ARYezB4KFHRfC1qCzxkD8qboFBCPp9mTpL4wscrYTuTBhZw/BAePSgu6RC3mdrvEgQGeIW4BgXI4HQ+ebEiDxGUkSpapeu1FnACALRlibmfwjE87z+D71SPft9o9YnRIBMxeWu9kU1wUJLeJKHSFfLwBkAbnb/MGTYuwPaJtY94MpCs3Fe9+4URMjuceWMMvabGCe9KplD8gPJCw9EqDzJjmA9Ie3BaIsRWwYZhS51uxaQvdTiGnxnmlJHT+y1WyK7dIAW3SfRqHzaf3VnYeTOfz0xErw4luHhVHO0HjNqhgGfML0rEYu5SJD4Gyeoj\"}","virtualAddress":"yadunandan.cruxdev.crux"}))
-				let cruxClient = new CruxClient(walletOptions);
-				let oldEncryptionKey = "fookey"
-				let newEncryptionKey = "fookey1"
-				await cruxClient.init()
-				await (cruxClient.getPayIDClaim()).decrypt(oldEncryptionKey)
-				let decryptedBeforeValue: PayIDClaim = cruxClient.getPayIDClaim()
-				await (cruxClient.getPayIDClaim()).encrypt(oldEncryptionKey)
-
-				// function being tested
-				let return_value = await cruxClient.updatePassword(oldEncryptionKey, newEncryptionKey)
-				expect(return_value).is.true
-
-				await (cruxClient.getPayIDClaim()).decrypt(newEncryptionKey)
-				let decryptedAfterValue: PayIDClaim = cruxClient.getPayIDClaim()
-
-				expect(decryptedBeforeValue.identitySecrets['mnemonic']).to.equal(decryptedAfterValue.identitySecrets['mnemonic'])
-				expect(decryptedBeforeValue.identitySecrets['identityKeyPair']).to.equal(decryptedAfterValue.identitySecrets['identityKeyPair'])
-				expect(decryptedBeforeValue.virtualAddress).to.equal(decryptedAfterValue.virtualAddress)
-				localStorage.clear();
-			})
-
-		})
-
-		describe("crux id tests", () => {
-			describe("payIDClaim not available in localStorage", () => {
-
-				it("getCruxIDState handling empty local storage",async () => {
-					localStorage.clear();
-					let cruxClient = new CruxClient(walletOptions);
-					let cruxIdState: ICruxIDState = await cruxClient.getCruxIDState()
-					expect(cruxIdState.status.cruxID).to.equal(undefined)
-				})
-			})
-
-			it("invalid getEncryptionKey provided", async () => {
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
-				let cruxClient = new CruxClient({
-					getEncryptionKey: () => "fookey1",
-					walletClientName: 'scatter_dev'
-				});
-				let raiseException = false
-				try {
-					await cruxClient.init()
-				} catch(e) {
-					console.log(e)
-					raiseException = true
-				}
-				expect(raiseException).to.equal(true)
-			})
-
-			it("invalid payIDClaim in local storage", async () => {
-				localStorage.setItem('payIDClaim', JSON.stringify({"identitySecrets":"{\"iv\":\"cxgg/vvP6XlWOwov\",\"encBuffer\":\"DX+FXU8rG4P2BQIZxWIV8R0DSc8WENREtf2PrIybw3cJLjk/90BYvpn+eC5c45Xb4tXHBW7ScxV26nR9OvDT5nT9SNyPZNIsFpnjnC83y31DodxgijK/ZPUGpPeA1ARYezB4KFHRfC1qCzxkD8qboFBCPp9mTpL4wscrYTuTBhZw/BAePSgu6RC3mdrvEgQGeIW4BgXI4HQ+ebEiDxGUkSpapeu1FnACALRlibmfwjE87z+D71SPft9o9YnRIBMxeWu9kU1wUJLeJKHSFfLwBkAbnb/MGTYuwPaJtY94MpCs3Fe9+4URMjuceWMMvabGCe9KplD8gPJCw9EqDzJjmA9Ie3BaIsRWwYZhS51uxaQvdTiGnxnmlJHT+y1WyK7dIAW3SfRqHzaf3VnYeTOfz0xErw4luHhVHO0HjNqhgGfML0rEYu5SJD4Gyeoj\"}","virtualAddress":"yadunandan.cruxdev_crux.id"}))
-				let cruxClient = new CruxClient(walletOptions);
-				let raiseException = false
-				try{
-					await cruxClient.init()
-				} catch(e) {
-					raiseException = true
-					// complete error msg:- `Error: Only .crux namespace is supported in CruxID`
-					expect(e.errorCode).to.equal(4005)
-				}
-				expect(raiseException).to.equal(true)
-			})
-		})
-
-		describe("registerCruxID tests", () => {
-			it("invalid name/subdomain 'cs1' provided", async () => {
-				// Mocks
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// registerCruxID
-				const subdomain = "cs1";
-				let raisedError;
-				try {
-					await cruxClient.registerCruxID(subdomain);
-				} catch(error) {
-					raisedError = error
-				}
-
-				// Expectations
-				expect(raisedError.errorCode).to.be.equal(PackageErrorCode.SubdomainLengthCheckFailure)
-
-			})
-			it("unavailable subdomain 'test' provided", async () => {
-				// Mocks
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(false);
-
-				// registerCruxID
-				const subdomain = "test";
-				let raisedError;
-				try {
-					await cruxClient.registerCruxID(subdomain);
-				} catch(error) {
-					raisedError = error
-				}
-
-				// Expectations
-				expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
-				expect(isCruxIDAvailableStub.calledOnce).is.true
-				expect(raisedError.errorCode).to.be.equal(PackageErrorCode.CruxIDUnavailable)
-
-			})
-			it("existing CruxID found in storage (payIDClaim)", async () => {
-				// Mocks
-				const mockPayIDClaim = sampleUser['payIDClaim'];
-				localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
-
-				// registerCruxID
-				const subdomain = "test";
-				let raisedError;
-				try {
-					await cruxClient.registerCruxID(subdomain);
-				} catch(error) {
-					raisedError = error
-				}
-
-				// Expectations
-				expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
-				expect(isCruxIDAvailableStub.calledOnce).is.true
-				expect(raisedError.errorCode).to.be.equal(PackageErrorCode.ExistingCruxIDFound)
-
-			})
-			it("registration failure with NameService error", async () => {
-				// Mocks
-				localStorage.clear();
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
-				// @ts-ignore
-				const nameServiceGenerateIdentityStub = sinon.stub(cruxClient._nameService, 'generateIdentity').resolves({secrets: sampleUser['decryptedPayIDClaim'].identitySecrets})
-				// @ts-ignore
-				const nameServiceRegisterNameStub = sinon.stub(cruxClient._nameService, 'registerName').rejects(ErrorHelper.getPackageError(PackageErrorCode.GaiaProfileUploadFailed));
-
-				// registerCruxID
-				const subdomain = "test";
-				let raisedError;
-				try {
-					await cruxClient.registerCruxID(subdomain);
-				} catch(error) {
-					raisedError = error
-				}
-
-				// Expectations
-				let identityClaim = {secrets: sampleUser['decryptedPayIDClaim'].identitySecrets}
-				// @ts-ignore
-				let storage = cruxClient._storage;
-				let encryptionKey = "fookey";
-
-				expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
-				expect(isCruxIDAvailableStub.calledOnce).is.true
-				expect(nameServiceGenerateIdentityStub.calledWith(storage, encryptionKey)).is.true
-				expect(nameServiceGenerateIdentityStub.calledOnce).is.true
-				expect(nameServiceRegisterNameStub.calledWith(identityClaim, subdomain)).is.true
-				expect(nameServiceRegisterNameStub.calledOnce).is.true
-				expect(raisedError.errorCode).to.be.equal(PackageErrorCode.GaiaProfileUploadFailed)
-
-			})
-			it("successful registration", async () => {
-				// Mocks
-				localStorage.clear();
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
-				// @ts-ignore
-				const nameServiceGenerateIdentityStub = sinon.stub(cruxClient._nameService, 'generateIdentity').resolves({secrets: sampleUser['decryptedPayIDClaim'].identitySecrets})
-				// @ts-ignore
-				const nameServiceRegisterNameStub = sinon.stub(cruxClient._nameService, 'registerName').resolves("test@scatter_dev.crux");
-
-				// registerCruxID
-				const subdomain = "test";
-				let registrationPromise = await cruxClient.registerCruxID(subdomain);
-
-				// Expectations
-				const identityClaim = {secrets: sampleUser['decryptedPayIDClaim'].identitySecrets}
-				// @ts-ignore
-				const storage = cruxClient._storage;
-				const encryptionKey = "fookey";
-				const virtualAddress = "test@scatter_dev.crux";
-				const mockPayIDClaim = {virtualAddress: "test@scatter_dev.crux", identitySecrets: sampleUser['payIDClaim'].identitySecrets};
-
-				expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
-				expect(isCruxIDAvailableStub.calledOnce).is.true
-				expect(nameServiceGenerateIdentityStub.calledWith(storage, encryptionKey)).is.true
-				expect(nameServiceGenerateIdentityStub.calledOnce).is.true
-				expect(nameServiceRegisterNameStub.calledWith(identityClaim, subdomain)).is.true
-				expect(nameServiceRegisterNameStub.calledOnce).is.true
-				expect(registrationPromise).to.be.undefined
-				// @ts-ignore
-				expect((await cruxClient._storage.getJSON('payIDClaim')).virtualAddress).is.to.equal(virtualAddress);
-				// @ts-ignore
-				expect((await cruxClient._storage.getJSON('payIDClaim')).identitySecrets).to.be.a('string');
-
-			})
-		})
-
-		describe("subdomain currency address resolution", () => {
-			it("positive case, exposed asset", async () => {
-				localStorage.clear();
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
-				let cruxClient = new CruxClient(walletOptions);
-				let mockedSampleAddress = sampleUser['addressMapping']
-
-				let mockedRevserseClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
-
-				let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedRevserseClientMapping)
-				let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
-
-				let resolvedAddress = await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "btc")
-				expect(resolvedAddress.addressHash).to.equal('19m51F8YkjzK625csaNtKnM9pgByeMJRU3')
-				clientMappingStub.restore()
-				addressMappingStub.restore()
-			})
-
-			it("unexposed asset in client-mapping", async () => {
-				localStorage.clear();
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
-				let cruxClient = new CruxClient(walletOptions);
-				let mockedSampleAddress = sampleUser['addressMapping']
-
-				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
-
-				let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
-				let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
-				let raisedException = false
-				try {
-					await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "ZRX")
-				} catch(e) {
-					raisedException = true
-					expect(e.errorCode).to.equal(1006)
-				} finally {
-					expect(raisedException).to.equal(true)
-					clientMappingStub.restore()
-					addressMappingStub.restore()
-				}
-			})
-
-			it("unexposed asset by subdomain", async () => {
-				localStorage.clear();
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
-				let cruxClient = new CruxClient(walletOptions);
-				let mockedSampleAddress = {"1234567-1e77-41e1-9ebb-0e216faa166a": {addressHash: "19m51F8YkjzK625csaNtKnM9pgByeMJRU3"}}
-
-				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
-
-				let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
-				let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
-				let raisedException = false
-				try {
-					await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "btc")
-				} catch(e) {
-					raisedException = true
-					expect(e.errorCode).to.equal(1005)
-				} finally {
-					expect(raisedException).to.equal(true)
-					clientMappingStub.restore()
-					addressMappingStub.restore()
-				}
-			})
-		})
-
-		describe("address mapping tests", () => {
-			it("positive case, get address map", async () => {
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']));
-				let cruxClient = new CruxClient(walletOptions);
-				let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
-				let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
-				let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(sampleUser['addressMapping'])
-				let gotAddMap = await cruxClient.getAddressMap()
-				expect(gotAddMap.btc.addressHash).to.equal('19m51F8YkjzK625csaNtKnM9pgByeMJRU3')
-				clientMappingStub.restore()
-				addressMappingStub.restore()
-			})
-
-			it("put address map, gaia upload call failed", async () => {
-				localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
-				let cruxClient = new CruxClient(walletOptions);
-				let raisesException = false
-				let updateProfileStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').rejects(ErrorHelper.getPackageError(PackageErrorCode.GaiaProfileUploadFailed))
-				try {
-					await cruxClient.putAddressMap(sampleAddressMap)
-				} catch(e) {
-					raisesException = true
-					expect(e.errorCode).to.equal(2005)
-				} finally {
-					expect(raisesException).to.be.true
-					updateProfileStub.restore()
-				}
-			})
-		})
-		describe("putAddressMap tests", () => {
-			it("all currencies provided exist in client mapping", async () => {
-				// Mocks
-				const mockPayIDClaim = sampleUser['payIDClaim'];
-				localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
-				let mockedAddressMap = sampleAddressMap;
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				// @ts-ignore
-				const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
-
-				// putAddressMap
-				const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
-
-				// Expectations
-				let decrpytedPayIDClaim = {secrets: sampleUser["decryptedPayIDClaim"].identitySecrets};
-				let assetIdMap = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": sampleAddressMap["BTC"], "508b8f73-4b06-453e-8151-78cb8cfc3bc9": sampleAddressMap["ETH"]};
-				let successCurrencies = {"btc": sampleAddressMap["BTC"], "eth": sampleAddressMap["ETH"]};
-
-				expect(nameServicePutAddressMappingStub.calledWith(decrpytedPayIDClaim, assetIdMap)).is.true;
-				expect(nameServicePutAddressMappingStub.calledOnce).is.true;
-				expect(failures).is.empty;
-				expect(success).to.be.eql(successCurrencies);
-
-			})
-			it("all currencies provided do not exist in client mapping", async () => {
-				// Mocks
-				const mockPayIDClaim = sampleUser['payIDClaim'];
-				localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
-				let mockedAddressMap = {
-					ZRX: {
-						addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
-					}
-				};
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				// @ts-ignore
-				const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
-
-				// putAddressMap
-				const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
-
-				// Expectations
-				expect(nameServicePutAddressMappingStub.calledOnce).is.true;
-				expect(failures.zrx).to.include(PackageErrorCode.CurrencyDoesNotExistInClientMapping);
-				expect(success).is.empty;
-
-			})
-			it("some of the currencies provided do not exist in client mapping", async () => {
-				// Mocks
-				const mockPayIDClaim = sampleUser['payIDClaim'];
-				localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
-				let mockedAddressMap = {
-					BTC: sampleAddressMap["BTC"],
-					ZRX: {
-						addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
-					}
-				};
-
-				// Initialising the CruxClient
-				let cruxClient = new CruxClient(walletOptions);
-
-				// stubbing runtime property
-				// @ts-ignore
-				const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
-
-				// putAddressMap
-				const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
-
-				// Expectations
-				let decrpytedPayIDClaim = {secrets: sampleUser["decryptedPayIDClaim"].identitySecrets};
-				let assetIdMap = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": sampleAddressMap["BTC"]};
-				let successCurrencies = {"btc": sampleAddressMap["BTC"]};
-
-				expect(nameServicePutAddressMappingStub.calledWith(decrpytedPayIDClaim, assetIdMap)).is.true;
-				expect(nameServicePutAddressMappingStub.calledOnce).is.true;
-				expect(failures.zrx).to.include(PackageErrorCode.CurrencyDoesNotExistInClientMapping);
-				expect(success).to.be.eql(successCurrencies);
-
-			})
-		})
-	})
+                httpJSONRequestStub.withArgs(requestObj.request).returns(requestObj.response)
+            });
+        })
+
+        after(() => {
+            httpJSONRequestStub.restore()
+            localStorage.clear();
+        })
+
+        describe('updatePassword tests', () => {
+
+            it('after encryption is mnemonic and identityKeyPair are same', async () => {
+                localStorage.setItem('payIDClaim', JSON.stringify({"identitySecrets":"{\"iv\":\"cxgg/vvP6XlWOwov\",\"encBuffer\":\"DX+FXU8rG4P2BQIZxWIV8R0DSc8WENREtf2PrIybw3cJLjk/90BYvpn+eC5c45Xb4tXHBW7ScxV26nR9OvDT5nT9SNyPZNIsFpnjnC83y31DodxgijK/ZPUGpPeA1ARYezB4KFHRfC1qCzxkD8qboFBCPp9mTpL4wscrYTuTBhZw/BAePSgu6RC3mdrvEgQGeIW4BgXI4HQ+ebEiDxGUkSpapeu1FnACALRlibmfwjE87z+D71SPft9o9YnRIBMxeWu9kU1wUJLeJKHSFfLwBkAbnb/MGTYuwPaJtY94MpCs3Fe9+4URMjuceWMMvabGCe9KplD8gPJCw9EqDzJjmA9Ie3BaIsRWwYZhS51uxaQvdTiGnxnmlJHT+y1WyK7dIAW3SfRqHzaf3VnYeTOfz0xErw4luHhVHO0HjNqhgGfML0rEYu5SJD4Gyeoj\"}","virtualAddress":"yadunandan.cruxdev.crux"}))
+                let cruxClient = new CruxClient(walletOptions);
+                let oldEncryptionKey = "fookey"
+                let newEncryptionKey = "fookey1"
+                await cruxClient.init()
+                await (cruxClient.getPayIDClaim()).decrypt(oldEncryptionKey)
+                let decryptedBeforeValue: PayIDClaim = cruxClient.getPayIDClaim()
+                await (cruxClient.getPayIDClaim()).encrypt(oldEncryptionKey)
+
+                // function being tested
+                let return_value = await cruxClient.updatePassword(oldEncryptionKey, newEncryptionKey)
+                expect(return_value).is.true
+
+                await (cruxClient.getPayIDClaim()).decrypt(newEncryptionKey)
+                let decryptedAfterValue: PayIDClaim = cruxClient.getPayIDClaim()
+
+                expect(decryptedBeforeValue.identitySecrets['mnemonic']).to.equal(decryptedAfterValue.identitySecrets['mnemonic'])
+                expect(decryptedBeforeValue.identitySecrets['identityKeyPair']).to.equal(decryptedAfterValue.identitySecrets['identityKeyPair'])
+                expect(decryptedBeforeValue.virtualAddress).to.equal(decryptedAfterValue.virtualAddress)
+                localStorage.clear();
+            })
+
+        })
+
+        describe("crux id tests", () => {
+            describe("payIDClaim not available in localStorage", () => {
+
+                it("getCruxIDState handling empty local storage",async () => {
+                    localStorage.clear();
+                    let cruxClient = new CruxClient(walletOptions);
+                    await cruxClient.init()
+                    let cruxIdState = await cruxClient.getCruxIDState()
+                    expect(cruxIdState.status.cruxID).to.equal(undefined)
+                })
+            })
+
+            it("invalid getEncryptionKey provided", async () => {
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
+                let cruxClient = new CruxClient({
+                    getEncryptionKey: () => "fookey1",
+                    walletClientName: 'scatter_dev'
+                });
+                let raiseException = false
+                try {
+                    await cruxClient.init()
+                } catch(e) {
+                    console.log(e)
+                    raiseException = true
+                }
+                expect(raiseException).to.equal(true)
+            })
+
+            it("invalid payIDClaim in local storage", async () => {
+                localStorage.setItem('payIDClaim', JSON.stringify({"identitySecrets":"{\"iv\":\"cxgg/vvP6XlWOwov\",\"encBuffer\":\"DX+FXU8rG4P2BQIZxWIV8R0DSc8WENREtf2PrIybw3cJLjk/90BYvpn+eC5c45Xb4tXHBW7ScxV26nR9OvDT5nT9SNyPZNIsFpnjnC83y31DodxgijK/ZPUGpPeA1ARYezB4KFHRfC1qCzxkD8qboFBCPp9mTpL4wscrYTuTBhZw/BAePSgu6RC3mdrvEgQGeIW4BgXI4HQ+ebEiDxGUkSpapeu1FnACALRlibmfwjE87z+D71SPft9o9YnRIBMxeWu9kU1wUJLeJKHSFfLwBkAbnb/MGTYuwPaJtY94MpCs3Fe9+4URMjuceWMMvabGCe9KplD8gPJCw9EqDzJjmA9Ie3BaIsRWwYZhS51uxaQvdTiGnxnmlJHT+y1WyK7dIAW3SfRqHzaf3VnYeTOfz0xErw4luHhVHO0HjNqhgGfML0rEYu5SJD4Gyeoj\"}","virtualAddress":"yadunandan.cruxdev_crux.id"}))
+                let cruxClient = new CruxClient(walletOptions);
+                let raiseException = false
+                try{
+                    await cruxClient.init()
+                } catch(e) {
+                    raiseException = true
+                    // complete error msg:- `Error: Only .crux namespace is supported in CruxID`
+                    expect(e.errorCode).to.equal(4005)
+                }
+                expect(raiseException).to.equal(true)
+            })
+        })
+
+        describe("registerCruxID tests", () => {
+            it("invalid name/subdomain 'cs1' provided", async () => {
+                // Mocks
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // registerCruxID
+                const subdomain = "cs1";
+                let raisedError;
+                try {
+                    await cruxClient.registerCruxID(subdomain);
+                } catch(error) {
+                    raisedError = error
+                }
+
+                // Expectations
+                expect(raisedError.errorCode).to.be.equal(PackageErrorCode.SubdomainLengthCheckFailure)
+
+            })
+            it("unavailable subdomain 'test' provided", async () => {
+                // Mocks
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(false);
+
+                // registerCruxID
+                const subdomain = "test";
+                let raisedError;
+                try {
+                    await cruxClient.registerCruxID(subdomain);
+                } catch(error) {
+                    raisedError = error
+                }
+
+                // Expectations
+                expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
+                expect(isCruxIDAvailableStub.calledOnce).is.true
+                expect(raisedError.errorCode).to.be.equal(PackageErrorCode.CruxIDUnavailable)
+
+            })
+            it("existing CruxID found in storage (payIDClaim)", async () => {
+                // Mocks
+                const mockPayIDClaim = sampleUser['payIDClaim'];
+                localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
+
+                // registerCruxID
+                const subdomain = "test";
+                let raisedError;
+                try {
+                    await cruxClient.registerCruxID(subdomain);
+                } catch(error) {
+                    raisedError = error
+                }
+
+                // Expectations
+                expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
+                expect(isCruxIDAvailableStub.calledOnce).is.true
+                expect(raisedError.errorCode).to.be.equal(PackageErrorCode.ExistingCruxIDFound)
+
+            })
+            it("registration failure with NameService error", async () => {
+                // Mocks
+                localStorage.clear();
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
+                // @ts-ignore
+                const nameServiceGenerateIdentityStub = sinon.stub(cruxClient._nameService, 'generateIdentity').resolves({secrets: sampleUser['decryptedPayIDClaim'].identitySecrets})
+                // @ts-ignore
+                const nameServiceRegisterNameStub = sinon.stub(cruxClient._nameService, 'registerName').rejects(ErrorHelper.getPackageError(PackageErrorCode.GaiaProfileUploadFailed));
+
+                // registerCruxID
+                const subdomain = "test";
+                let raisedError;
+                try {
+                    await cruxClient.registerCruxID(subdomain);
+                } catch(error) {
+                    raisedError = error
+                }
+
+                // Expectations
+                let identityClaim = {secrets: sampleUser['decryptedPayIDClaim'].identitySecrets}
+                // @ts-ignore
+                let storage = cruxClient._storage;
+                let encryptionKey = "fookey";
+
+                expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
+                expect(isCruxIDAvailableStub.calledOnce).is.true
+                expect(nameServiceGenerateIdentityStub.calledWith(storage, encryptionKey)).is.true
+                expect(nameServiceGenerateIdentityStub.calledOnce).is.true
+                expect(nameServiceRegisterNameStub.calledWith(identityClaim, subdomain)).is.true
+                expect(nameServiceRegisterNameStub.calledOnce).is.true
+                expect(raisedError.errorCode).to.be.equal(PackageErrorCode.GaiaProfileUploadFailed)
+
+            })
+            it("successful registration", async () => {
+                // Mocks
+                localStorage.clear();
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                const isCruxIDAvailableStub = sinon.stub(cruxClient, 'isCruxIDAvailable').resolves(true);
+                // @ts-ignore
+                const nameServiceGenerateIdentityStub = sinon.stub(cruxClient._nameService, 'generateIdentity').resolves({secrets: sampleUser['decryptedPayIDClaim'].identitySecrets})
+                // @ts-ignore
+                const nameServiceRegisterNameStub = sinon.stub(cruxClient._nameService, 'registerName').resolves("test@scatter_dev.crux");
+
+                // registerCruxID
+                const subdomain = "test";
+                let registrationPromise = await cruxClient.registerCruxID(subdomain);
+
+                // Expectations
+                const identityClaim = {secrets: sampleUser['decryptedPayIDClaim'].identitySecrets}
+                // @ts-ignore
+                const storage = cruxClient._storage;
+                const encryptionKey = "fookey";
+                const virtualAddress = "test@scatter_dev.crux";
+                const mockPayIDClaim = {virtualAddress: "test@scatter_dev.crux", identitySecrets: sampleUser['payIDClaim'].identitySecrets};
+
+                expect(isCruxIDAvailableStub.calledWith(subdomain)).is.true
+                expect(isCruxIDAvailableStub.calledOnce).is.true
+                expect(nameServiceGenerateIdentityStub.calledWith(storage, encryptionKey)).is.true
+                expect(nameServiceGenerateIdentityStub.calledOnce).is.true
+                expect(nameServiceRegisterNameStub.calledWith(identityClaim, subdomain)).is.true
+                expect(nameServiceRegisterNameStub.calledOnce).is.true
+                expect(registrationPromise).to.be.undefined
+                // @ts-ignore
+                expect((await cruxClient._storage.getJSON('payIDClaim')).virtualAddress).is.to.equal(virtualAddress);
+                // @ts-ignore
+                expect((await cruxClient._storage.getJSON('payIDClaim')).identitySecrets).to.be.a('string');
+
+            })
+        })
+
+        describe("subdomain currency address resolution", () => {
+            it("positive case, exposed asset", async () => {
+                localStorage.clear();
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init()
+                let mockedSampleAddress = sampleUser['addressMapping']
+
+                let mockedRevserseClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
+
+                let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedRevserseClientMapping)
+                let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
+
+                let resolvedAddress = await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "btc")
+                expect(resolvedAddress.addressHash).to.equal('19m51F8YkjzK625csaNtKnM9pgByeMJRU3')
+                clientMappingStub.restore()
+                addressMappingStub.restore()
+            })
+
+            it("unexposed asset in client-mapping", async () => {
+                localStorage.clear();
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init()
+                let mockedSampleAddress = sampleUser['addressMapping']
+
+                let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
+
+                let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
+                let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
+                let raisedException = false
+                try {
+                    await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "ZRX")
+                } catch(e) {
+                    raisedException = true
+                    expect(e.errorCode).to.equal(1006)
+                } finally {
+                    expect(raisedException).to.equal(true)
+                    clientMappingStub.restore()
+                    addressMappingStub.restore()
+                }
+            })
+
+            it("unexposed asset by subdomain", async () => {
+                localStorage.clear();
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init()
+                let mockedSampleAddress = {"1234567-1e77-41e1-9ebb-0e216faa166a": {addressHash: "19m51F8YkjzK625csaNtKnM9pgByeMJRU3"}}
+
+                let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
+
+                let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
+                let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(mockedSampleAddress)
+                let raisedException = false
+                try {
+                    await cruxClient.resolveCurrencyAddressForCruxID(sampleUser['cruxID'], "btc")
+                } catch(e) {
+                    raisedException = true
+                    expect(e.errorCode).to.equal(1005)
+                } finally {
+                    expect(raisedException).to.equal(true)
+                    clientMappingStub.restore()
+                    addressMappingStub.restore()
+                }
+            })
+        })
+
+        describe("address mapping tests", () => {
+            it("positive case, get address map", async () => {
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']));
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init()
+                let mockedClientMapping = {'1d6e1a99-1e77-41e1-9ebb-0e216faa166a': 'btc' }
+                let clientMappingStub = sinon.stub(cruxClient._configService, 'reverseClientAssetMapping').value(mockedClientMapping)
+                let addressMappingStub = sinon.stub(cruxClient._nameService, 'getAddressMapping').returns(sampleUser['addressMapping'])
+                let gotAddMap = await cruxClient.getAddressMap()
+                expect(gotAddMap.btc.addressHash).to.equal('19m51F8YkjzK625csaNtKnM9pgByeMJRU3')
+                clientMappingStub.restore()
+                addressMappingStub.restore()
+            })
+
+            it("put address map, gaia upload call failed", async () => {
+                localStorage.setItem('payIDClaim', JSON.stringify(sampleUser['payIDClaim']))
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init()
+                let raisesException = false
+                let updateProfileStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').rejects(ErrorHelper.getPackageError(PackageErrorCode.GaiaProfileUploadFailed))
+                try {
+                    await cruxClient.putAddressMap(sampleAddressMap)
+                } catch(e) {
+                    raisesException = true
+                    expect(e.errorCode).to.equal(2005)
+                } finally {
+                    expect(raisesException).to.be.true
+                    updateProfileStub.restore()
+                }
+            })
+        })
+        describe("putAddressMap tests", () => {
+            it("all currencies provided exist in client mapping", async () => {
+                // Mocks
+                const mockPayIDClaim = sampleUser['payIDClaim'];
+                localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
+                let mockedAddressMap = sampleAddressMap;
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                // @ts-ignore
+                const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
+
+                // putAddressMap
+                const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
+
+                // Expectations
+                let decrpytedPayIDClaim = {secrets: sampleUser["decryptedPayIDClaim"].identitySecrets};
+                let assetIdMap = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": sampleAddressMap["BTC"], "508b8f73-4b06-453e-8151-78cb8cfc3bc9": sampleAddressMap["ETH"]};
+                let successCurrencies = {"btc": sampleAddressMap["BTC"], "eth": sampleAddressMap["ETH"]};
+
+                expect(nameServicePutAddressMappingStub.calledWith(decrpytedPayIDClaim, assetIdMap)).is.true;
+                expect(nameServicePutAddressMappingStub.calledOnce).is.true;
+                expect(failures).is.empty;
+                expect(success).to.be.eql(successCurrencies);
+
+            })
+            it("all currencies provided do not exist in client mapping", async () => {
+                // Mocks
+                const mockPayIDClaim = sampleUser['payIDClaim'];
+                localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
+                let mockedAddressMap = {
+                    ZRX: {
+                        addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
+                    }
+                };
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                // @ts-ignore
+                const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
+
+                // putAddressMap
+                const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
+
+                // Expectations
+                expect(nameServicePutAddressMappingStub.calledOnce).is.true;
+                expect(failures.zrx).to.include(PackageErrorCode.CurrencyDoesNotExistInClientMapping);
+                expect(success).is.empty;
+
+            })
+            it("some of the currencies provided do not exist in client mapping", async () => {
+                // Mocks
+                const mockPayIDClaim = sampleUser['payIDClaim'];
+                localStorage.setItem('payIDClaim', JSON.stringify(mockPayIDClaim));
+                let mockedAddressMap = {
+                    BTC: sampleAddressMap["BTC"],
+                    ZRX: {
+                        addressHash: '0x0a2311594059b468c9897338b027c8782398b481'
+                    }
+                };
+
+                // Initialising the CruxClient
+                let cruxClient = new CruxClient(walletOptions);
+                await cruxClient.init();
+
+                // stubbing runtime property
+                // @ts-ignore
+                const nameServicePutAddressMappingStub = sinon.stub(cruxClient._nameService, 'putAddressMapping').resolves();
+
+                // putAddressMap
+                const {success, failures} = await cruxClient.putAddressMap(mockedAddressMap)
+
+                // Expectations
+                let decrpytedPayIDClaim = {secrets: sampleUser["decryptedPayIDClaim"].identitySecrets};
+                let assetIdMap = {"1d6e1a99-1e77-41e1-9ebb-0e216faa166a": sampleAddressMap["BTC"]};
+                let successCurrencies = {"btc": sampleAddressMap["BTC"]};
+
+                expect(nameServicePutAddressMappingStub.calledWith(decrpytedPayIDClaim, assetIdMap)).is.true;
+                expect(nameServicePutAddressMappingStub.calledOnce).is.true;
+                expect(failures.zrx).to.include(PackageErrorCode.CurrencyDoesNotExistInClientMapping);
+                expect(success).to.be.eql(successCurrencies);
+
+            })
+        })
+    })
 
 })


### PR DESCRIPTION
- getAssetMap returns promise of IResolvedClientAssetMapping
- Init is called in constructor now all functions exposed 
-  Allows modewise(withoutInit or withInit) testing of wallet_demo page 